### PR TITLE
updated two links

### DIFF
--- a/_weave/lecture16/probabilistic_programming.jmd
+++ b/_weave/lecture16/probabilistic_programming.jmd
@@ -449,7 +449,7 @@ approximates the flow. This means that:
 - Steps preserve area. In the sense of Hamiltonian Monte Carlo, this means
   preserve probability and thus increase the acceptance rate.
 
-These properties are demonstrated in [the Kepler problem demo](https://tutorials.juliadiffeq.org/html/models/05-kepler_problem.html).
+These properties are demonstrated in [the Kepler problem demo](https://docs.sciml.ai/SciMLTutorialsOutput/html/models/05-kepler_problem.html).
 However, note that while the solution lives on a symplectic manifold, it isn't
 necessarily the correct symplectic manifold. The shift in the manifold is
 $\mathcal{O}(\Delta t^k)$ where $k$ is the order of the method. For more
@@ -460,7 +460,7 @@ information on symplectic integration, consult
 
 For a full demo of probabilistic programming on a differential equation system,
 see
-[this tutorial on Bayesian inference of pendulum parameters](https://tutorials.juliadiffeq.org/html/models/06-pendulum_bayesian_inference.html)
+[this tutorial on Bayesian inference of pendulum parameters](https://docs.sciml.ai/SciMLTutorialsOutput/html/models/06-pendulum_bayesian_inference.html)
 utilizing DifferentialEquations.jl and DiffEqBayes.jl.
 
 ## Bayesian Estimation of Posterior Distributions with Variational Inference


### PR DESCRIPTION
updated two links to be docs.sciml.ai links

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
