### PR TITLE
Fix typos in Chapters 5, 7, and 15

### DIFF
--- a/_weave/lecture05/parallelism_overview.jmd
+++ b/_weave/lecture05/parallelism_overview.jmd
@@ -302,7 +302,7 @@ with this code. For one, we had to go to the slower heap+mutation version, so
 its implementation starting point is slower. But secondly, and more importantly,
 the cost of spinning a new thread is non-negligible. In fact, here we can see
 that it even needs to make a small allocation for the new context. The total
-cost is on the order of It's on the order of 50ns: not huge, but something
+cost is on the order of 50ns: not huge, but something
 to take note of. So what we've done is taken almost free calculations and made
 them ~50ns by making each in a different thread, instead of just having it be
 one thread with one call stack.

--- a/_weave/lecture07/discretizing_odes.jmd
+++ b/_weave/lecture07/discretizing_odes.jmd
@@ -436,7 +436,7 @@ We need to make a choice as to where we evaluate $f$ at. The simplest approximat
 is to evaluate it at $t_n$ with $u_n$ where we already have the data, and thus
 we re-arrange to get
 
-$$u_{n+1} = u_n + \Delta t f(u,p,t)$$
+$$u_{n+1} = u_n + \Delta t f(u_n,p,t_n)$$
 
 This is the Euler method.
 

--- a/_weave/lecture15/diffeq_machine_learning.jmd
+++ b/_weave/lecture15/diffeq_machine_learning.jmd
@@ -445,10 +445,10 @@ and a set of derivative observations
 
 $$\begin{array}{c}
 \dot{\mathbf{X}}=\left[\begin{array}{c}
-\mathbf{x}^{T}\left(t_{1}\right) \\
+\dot{\mathbf{x}}^{T}\left(t_{1}\right) \\
 \dot{\mathbf{x}}^{T}\left(t_{2}\right) \\
 \vdots \\
-\mathbf{x}^{T}\left(t_{m}\right)
+\dot{\mathbf{x}}^{T}\left(t_{m}\right)
 \end{array}\right]=\left[\begin{array}{cccc}
 \dot{x}_{1}\left(t_{1}\right) & \dot{x}_{2}\left(t_{1}\right) & \cdots & \dot{x}_{n}\left(t_{1}\right) \\
 \dot{x}_{1}\left(t_{2}\right) & \dot{x}_{2}\left(t_{2}\right) & \cdots & \dot{x}_{n}\left(t_{2}\right) \\


### PR DESCRIPTION
This PR fixes the typos reported in issue #156 

- Fix typo in Chapter 5 (“It’s on the order of 50ns”)

- Correct notation in Chapter 7 for Euler method

- Add dot notation to derivatives in Chapter 15