### PR TITLE
Fix Lux output type error in dudt_: correctly extract scalar from net…

### DIFF
--- a/_weave/lecture15/diffeq_machine_learning.jmd
+++ b/_weave/lecture15/diffeq_machine_learning.jmd
@@ -114,7 +114,8 @@ p3 = ComponentArray(nn=p_nn, ode=p_ode)
 
 function dudt_(du,u,p,t)
     x, y = u
-    du[1] = first(ann(u, p.nn, st))
+    nn_out, _ = ann(u, p.nn, st)
+    du[1] = nn_out[1]
     du[2] = p.ode[1]*y + p.ode[2]*x
 end
 prob = ODEProblem(dudt_,u0,tspan,p3)


### PR DESCRIPTION
Fixes a type error in dudt_ when using Lux.

The original code used:
    du[1] = first(ann(u, p.nn, st))

However, `ann` returns (output, state), so `first(...)` extracts the output vector, not a scalar, causing a type mismatch.

This patch correctly destructures the output:
    nn_out, _ = ann(u, p.nn, st)
    du[1] = nn_out[1]

This ensures du[1] receives a scalar value as expected.

## Checklist
- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
 
