### PR TITLE
Fix sign errors in adjoint ODE derivation (lecture 11)

### DIFF
--- a/_weave/lecture11/adjoints.html
+++ b/_weave/lecture11/adjoints.html
@@ -166,14 +166,14 @@ I(p) = G(p) - \int_{t_0}^T \lambda^\ast (u^\prime - f(u,p,t))dt
 \]</p>
 <p>To see where we ended up, let&#39;s re-arrange the full expression now:</p>
 <p class="math">\[
-\frac{dG}{dp}	=\int_{t_{0}}^{T}(g_{p}+g_{u}s)dt+|\lambda^{\ast}(t)s(t)|_{t_{0}}^{T}-\int_{t_{0}}^{T}\lambda^{\ast\prime}sdt-\int_{t_{0}}^{T}\lambda^{\ast}\left(f_{u}s+f_{p}\right)dt
+\frac{dG}{dp}	=\int_{t_{0}}^{T}(g_{p}+g_{u}s)dt-|\lambda^{\ast}(t)s(t)|_{t_{0}}^{T}+\int_{t_{0}}^{T}\lambda^{\ast\prime}sdt+\int_{t_{0}}^{T}\lambda^{\ast}\left(f_{u}s+f_{p}\right)dt
 \]</p>
 <p class="math">\[
-=\int_{t_{0}}^{T}(g_{p}+\lambda^{\ast}f_{p})dt+|\lambda^{\ast}(t)s(t)|_{t_{0}}^{T}-\int_{t_{0}}^{T}\left(\lambda^{\ast\prime}+\lambda^\ast f_{u}-g_{u}\right)sdt
+=\int_{t_{0}}^{T}(g_{p}+\lambda^{\ast}f_{p})dt-|\lambda^{\ast}(t)s(t)|_{t_{0}}^{T}+\int_{t_{0}}^{T}\left(\lambda^{\ast\prime}+\lambda^\ast f_{u}+g_{u}\right)sdt
 \]</p>
 <p>That was just a re-arrangement. Now, let&#39;s require that</p>
 <p class="math">\[
-\lambda^\prime = -\frac{df}{du}^\ast \lambda + \left(\frac{dg}{du} \right)^\ast
+\lambda^\prime = -\frac{df}{du}^\ast \lambda - \left(\frac{dg}{du} \right)^\ast
 \]</p>
 <p class="math">\[
 \lambda(T) = 0

--- a/_weave/lecture11/adjoints.jmd
+++ b/_weave/lecture11/adjoints.jmd
@@ -741,12 +741,12 @@ $$=|\lambda^{\ast}(t)s(t)|_{t_{0}}^{T}-\int_{t_{0}}^{T}\lambda^{\ast\prime}sdt-\
 
 To see where we ended up, let's re-arrange the full expression now:
 
-$$\frac{dG}{dp}	=\int_{t_{0}}^{T}(g_{p}+g_{u}s)dt+|\lambda^{\ast}(t)s(t)|_{t_{0}}^{T}-\int_{t_{0}}^{T}\lambda^{\ast\prime}sdt-\int_{t_{0}}^{T}\lambda^{\ast}\left(f_{u}s+f_{p}\right)dt$$
-$$=\int_{t_{0}}^{T}(g_{p}+\lambda^{\ast}f_{p})dt+|\lambda^{\ast}(t)s(t)|_{t_{0}}^{T}-\int_{t_{0}}^{T}\left(\lambda^{\ast\prime}+\lambda^\ast f_{u}-g_{u}\right)sdt$$
+$$\frac{dG}{dp}	=\int_{t_{0}}^{T}(g_{p}+g_{u}s)dt-|\lambda^{\ast}(t)s(t)|_{t_{0}}^{T}+\int_{t_{0}}^{T}\lambda^{\ast\prime}sdt+\int_{t_{0}}^{T}\lambda^{\ast}\left(f_{u}s+f_{p}\right)dt$$
+$$=\int_{t_{0}}^{T}(g_{p}+\lambda^{\ast}f_{p})dt-|\lambda^{\ast}(t)s(t)|_{t_{0}}^{T}+\int_{t_{0}}^{T}\left(\lambda^{\ast\prime}+\lambda^\ast f_{u}+g_{u}\right)sdt$$
 
 That was just a re-arrangement. Now, let's require that
 
-$$\lambda^\prime = -\frac{df}{du}^\ast \lambda + \left(\frac{dg}{du} \right)^\ast$$
+$$\lambda^\prime = -\frac{df}{du}^\ast \lambda - \left(\frac{dg}{du} \right)^\ast$$
 $$\lambda(T) = 0$$
 
 This means that one of the boundary terms of the integration by parts is zero, and also one of those integrals is perfectly zero.


### PR DESCRIPTION
## Summary

Fixes #197. The derivation of the adjoint of ordinary differential equations in `_weave/lecture11/adjoints.jmd` has three sign errors immediately after the integration-by-parts step.

Starting from
$$\frac{dG}{dp} = \int_{t_0}^{T}(g_p + g_u s)\,dt - \int_{t_0}^{T}\lambda^\ast (s' - f_u s - f_p)\,dt$$

the lecture correctly derives the IBP identity

$$\int_{t_0}^{T}\lambda^\ast (s' - f_u s - f_p)\,dt = |\lambda^\ast s|_{t_0}^{T} - \int_{t_0}^{T}\lambda^{\ast\prime} s\, dt - \int_{t_0}^{T}\lambda^\ast (f_u s + f_p)\, dt$$

but the next line substitutes it into $dG/dp$ without distributing the leading minus sign. That flips the signs on the boundary term and both inner integrals. The rearrangement one line later inherits the error and also flips the $g_u$ sign. The adjoint equation then appears as $\lambda' = -(df/du)^\ast \lambda + (dg/du)^\ast$, which contradicts the same equation written later in the lecture (lines 783 and 816) with the correct $-(dg/du)^\ast$.

Correct post-IBP expression:
$$\frac{dG}{dp} = \int_{t_0}^{T}(g_p + \lambda^\ast f_p)\, dt - |\lambda^\ast s|_{t_0}^{T} + \int_{t_0}^{T}(\lambda^{\ast\prime} + \lambda^\ast f_u + g_u) s\, dt$$

With adjoint $\lambda' = -(df/du)^\ast \lambda - (dg/du)^\ast$, $\lambda(T)=0$, the $s$-integral vanishes and the $T$ boundary term drops, recovering the existing final result on line 755.

Changes:
- `_weave/lecture11/adjoints.jmd`: fix the two rearranged $dG/dp$ lines and the adjoint ODE line.
- `_weave/lecture11/adjoints.html`: mirror the same fixes (HTML is committed alongside the jmd in this repo).

## Test plan
- [x] Verified the corrected adjoint matches the equations given later in the same lecture (lines 783, 816) and the final formula on line 755.
- [x] Confirmed the rendered HTML in `adjoints.html` matches the corrected jmd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)