### PR TITLE
Fix lecture07 midpoint-method local truncation error derivation

### DIFF
--- a/_weave/lecture07/discretizing_odes.jmd
+++ b/_weave/lecture07/discretizing_odes.jmd
@@ -485,20 +485,20 @@ where $f_n = f(u_n,p,t)$. If we do the two-dimensional Taylor expansion we get:
 
 ```math
 u_{n+1} = u_n + \Delta t f_n + \frac{\Delta t^2}{2}(f_t + f_u f)(u_n,p,t)\\
-+ \frac{\Delta t^3}{6} (f_{tt} + 2f_{tu}f + f_{uu}f^2)(u_n,p,t)
++ \frac{\Delta t^3}{8} (f_{tt} + 2f_{tu}f + f_{uu}f^2)(u_n,p,t)
 ```
 
 which when we compare against the true Taylor series:
 
 ```math
 u(t+\Delta t) = u_n + \Delta t f(u_n,p,t) + \frac{\Delta t^2}{2}(f_t + f_u f)(u_n,p,t)
-+ \frac{\Delta t^3}{6}(f_{tt} + 2f_{tu} + f_{uu}f^2 + f_t f_u + f_u^2 f)(u_n,p,t)
++ \frac{\Delta t^3}{6}(f_{tt} + 2f_{tu}f + f_{uu}f^2 + f_t f_u + f_u^2 f)(u_n,p,t)
 ```
 
 and thus we see that
 
 ```math
-u(t + \Delta t) - u_n = \mathcal{O}(\Delta t^3)
+u(t + \Delta t) - u_{n+1} = \mathcal{O}(\Delta t^3)
 ```
 
 ### Runge-Kutta Methods


### PR DESCRIPTION
## Summary

Fixes #202. The Higher Order Methods section in `_weave/lecture07/discretizing_odes.jmd` had three related errors in the midpoint-method Taylor expansion:

1. **Numerical update coefficient**: $\frac{\Delta t^3}{6}$ → $\frac{\Delta t^3}{8}$. Midpoint is $u_{n+1} = u_n + \Delta t\, f(u_n + \tfrac{\Delta t}{2} f_n,\, t + \tfrac{\Delta t}{2})$. Expanding the inner $f$ gives a $\tfrac{\Delta t^2}{8}(f_{tt} + 2 f_{tu} f + f_{uu} f^2)$ term, which contributes $\tfrac{\Delta t^3}{8}$ after the outer $\Delta t$.
2. **True Taylor series typo**: $2 f_{tu}$ → $2 f_{tu} f$. Comes from differentiating $u'' = f_t + f_u f$ once more — every chain-rule pickup of $u'$ leaves an $f$ behind.
3. **Truncation error LHS** (the issue's main correction): $u(t + \Delta t) - u_n$ → $u(t + \Delta t) - u_{n+1}$. The local truncation error compares the exact solution to the numerical update at step $n+1$. The previous form would just be $\mathcal{O}(\Delta t)$, defeating the point of showing the method is order 2.

Thanks to @waitpersistence for catching all three.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>