### PR TITLE
fix: typo contravariant -> covariant in lecture03

### DIFF
--- a/_weave/lecture03/sciml.jmd
+++ b/_weave/lecture03/sciml.jmd
@@ -312,7 +312,7 @@ to be able to optimize with respect to which function we are handling inside of
 another function, then we need "what function we are dealing with" as compile-time
 information, which necessitates being type information.
 
-Tuples are contravariant and heterogeneously typed with a parameter per internal
+Tuples are covariant and heterogeneously typed with a parameter per internal
 object. For example:
 
 ```julia


### PR DESCRIPTION
Fixes #138

Changed "contravariant" to "covariant" in lecture03/sciml.jmd line 312.