### PR TITLE
Fix/lecture16 log typo

### DIFF
--- a/_weave/lecture03/sciml.jmd
+++ b/_weave/lecture03/sciml.jmd
@@ -312,7 +312,7 @@ to be able to optimize with respect to which function we are handling inside of
 another function, then we need "what function we are dealing with" as compile-time
 information, which necessitates being type information.
 
-Tuples are contravariant and heterogeneously typed with a parameter per internal
+Tuples are covariant and heterogeneously typed with a parameter per internal
 object. For example:
 
 ```julia

--- a/_weave/lecture16/probabilistic_programming.jmd
+++ b/_weave/lecture16/probabilistic_programming.jmd
@@ -385,7 +385,7 @@ that includes momentum, we simply need to choose a conditional distribution
 $\pi(p|x)$. This would mean that
 
 $$\begin{align}
-H(x,p) &= -log \pi(p|x) - \log \pi(x)\\
+H(x,p) &= -\log \pi(p|x) - \log \pi(x)\\
        &= K(p,x) + V(x)
 \end{align}$$
 


### PR DESCRIPTION
Fixes #62

`-log` → `-\log` on line 388.